### PR TITLE
Implement own kana extraction logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
 jobs:
   bundle_npm_dependencies:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -37,7 +37,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -71,7 +71,7 @@ jobs:
 
   typecheck:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     working_directory: ~/react-use-kana
     steps:
       - checkout

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,5 +30,7 @@ module.exports = {
     },
   },
   globals: {},
-  rules: {},
+  rules: {
+    'no-irregular-whitespace': ['error', { skipRegExps: true }],
+  },
 };

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ ReactDOM.render(<App />, document.getElementById('root'));
 This library uses:
 
 - [React Hooks](https://reactjs.org/docs/hooks-intro.html)
-- [historykana](https://github.com/terrierscript/historykana) (Many thanks to @terrierscript)
 
 ## Requirement
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": ">=16.8"
   },
   "devDependencies": {
+    "@babel/core": "^7.6.4",
     "@testing-library/react-hooks": "^2.0.1",
     "@types/historykana": "^1.0.0",
     "@types/jest": "^24.0.18",
@@ -45,6 +46,7 @@
     "@types/react-test-renderer": "^16.9.0",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",
+    "babel-jest": "^24.9.0",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-jest": "^22.17.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "prettier": "prettier --list-different \"src/**/*.{ts,tsx}\"",
     "prettier:fix": "prettier --write \"src/**/*.{ts,tsx}\""
   },
-  "dependencies": {
-    "historykana": "^1.0.4"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react": ">=16.8"
   },

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -1,28 +1,149 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useKana } from '../useKana';
 
-test('returns kana based on user input', () => {
-  const { result } = renderHook(() => useKana());
+describe('when several kanas are converted to kanjis at once', () => {
+  it('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
 
-  expect(result.current.kana).toEqual('');
-
-  // Emulates to input a user's last name
-  [
-    'や',
-    'やｍ',
-    'やま',
-    'やまｄ',
-    'やまだ',
-    '山田',
-    '山田い',
-    '山田井',
-  ].forEach(value => {
-    act(() => {
-      result.current.setKanaSource({
-        value,
+    expect(result.current.kana).toEqual('');
+    ['や', 'やｍ', 'やま', 'やまｄ', 'やまだ', '山田'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource({
+          value,
+        });
       });
     });
+    expect(result.current.kana).toEqual('やまだ');
   });
+});
 
-  expect(result.current.kana).toEqual('やまだい');
+describe('when kanas are converted to kanjis one by one', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource({
+          value,
+        });
+      });
+    });
+    expect(result.current.kana).toEqual('やまだ');
+  });
+});
+
+describe('when kanas are converted to kanjis one by one', () => {
+  // TODO Fix a bug
+  test.skip('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田', '山打'].forEach(
+      value => {
+        act(() => {
+          result.current.setKanaSource({
+            value,
+          });
+        });
+      },
+    );
+    expect(result.current.kana).toEqual('やまだ');
+  });
+});
+
+describe('when kanas are converted to katakana', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(
+      value => {
+        act(() => {
+          result.current.setKanaSource({
+            value,
+          });
+        });
+      },
+    );
+    expect(result.current.kana).toEqual('くりす');
+  });
+});
+
+describe('when conversion happened from head', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['ｄ', 'だ', '田', 'い田', 'いい田', '飯田'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource({
+          value,
+        });
+      });
+    });
+    expect(result.current.kana).toEqual('いいだ');
+  });
+});
+
+describe('when a full-width space between characters is given', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(
+      value => {
+        act(() => {
+          result.current.setKanaSource({
+            value,
+          });
+        });
+      },
+    );
+    expect(result.current.kana).toEqual('り　あい');
+  });
+});
+
+describe('when a half-width space between characters is given', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(
+      value => {
+        act(() => {
+          result.current.setKanaSource({
+            value,
+          });
+        });
+      },
+    );
+    expect(result.current.kana).toEqual('り あい');
+  });
+});
+
+describe('when a half-width space between characters is given', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    [
+      'ｒ',
+      'り',
+      '李',
+      '李',
+      '李 ',
+      '李  ',
+      '李  あ',
+      '李  あい',
+      '李  愛',
+    ].forEach(value => {
+      act(() => {
+        result.current.setKanaSource({
+          value,
+        });
+      });
+    });
+    expect(result.current.kana).toEqual('り  あい');
+  });
 });

--- a/src/useKana.tsx
+++ b/src/useKana.tsx
@@ -1,17 +1,149 @@
 import { useState } from 'react';
-import historykana from 'historykana';
+
+interface KanaMap {
+  [key: string]: string;
+}
+
+interface Diff {
+  added: string[];
+  removed: string[];
+}
+
+interface KanaPair {
+  nonKana: string;
+  kana: string;
+}
+
+const KANA_REGEX = /([ 　ぁあ-んー]+)/g;
+const NON_KANA_REGEX = /([^ 　ぁあ-んー]+)/g;
+const SPACE_REGEX = /([ 　]+)/g;
+
+const isKana = (value: string): boolean => !!value.match(KANA_REGEX);
+const isNonKana = (value: string): boolean => !!value.match(NON_KANA_REGEX);
+
+// Split into kanas, spaces, other characters
+// Filter out empty values
+const splitIntoCharGroups = (value: string): string[] => {
+  return value
+    .split(KANA_REGEX)
+    .flatMap(str => str.split(SPACE_REGEX))
+    .filter(Boolean);
+};
+
+const extractDiff = (from: string[], to: string[]): Diff => {
+  const added = to.filter(x => !from.includes(x));
+  const removed = from.filter(x => !to.includes(x));
+  return { added, removed };
+};
+
+const extractPair = ({ added, removed }: Diff): KanaPair | undefined => {
+  if (
+    added.length === 1 &&
+    removed.length === 1 &&
+    isNonKana(added[0]) &&
+    isKana(removed[0])
+  ) {
+    // given
+    //   added: ['山田']
+    //   removed: ['やまだ']
+    // then
+    //   paid is { '山田': 'やまだ' }
+    return {
+      nonKana: added[0],
+      kana: removed[0],
+    };
+  } else if (removed.length === 2 && added.length === 1) {
+    // given
+    //   added: ['山田']
+    //   removed: ['山', 'だ']
+    // then
+    //   pair is { '田': 'だ' }
+    //
+    // given
+    //   added: ['山田']
+    //   removed: ['やま', '田']
+    // then
+    //   pair is { '山': 'やま' }
+    const nonKana = added[0].replace(
+      new RegExp(`${removed.join('|')}`, 'g'),
+      '',
+    );
+    const kana = removed.find(isKana) as string;
+    return {
+      nonKana,
+      kana,
+    };
+  } else {
+    return;
+  }
+};
+
+// Create a map that contains pairs of non-kana and kana
+const createMap = (
+  kanaMap: KanaMap,
+  previousCharGroups: string[],
+  currentCharGroups: string[],
+): KanaMap => {
+  const diff = extractDiff(previousCharGroups, currentCharGroups);
+  const pair = extractPair(diff);
+  if (pair) {
+    return {
+      ...kanaMap,
+      [pair.nonKana]: pair.kana,
+    };
+  } else {
+    return { ...kanaMap };
+  }
+};
+
+const convertCharGroupsToKana = (
+  kanaMap: KanaMap,
+  charGroups: string[],
+): string => {
+  const knownNonKanas = Object.keys(kanaMap);
+  return charGroups
+    .map(chars => {
+      return knownNonKanas
+        .filter(knownNonKana => chars.indexOf(knownNonKana) >= 0)
+        .reduce(
+          (memo, nonKana) => memo.replace(nonKana, kanaMap[nonKana]),
+          chars,
+        );
+    })
+    .filter(isKana)
+    .join('');
+};
 
 export const useKana = (): {
   kana: string;
   setKanaSource: ({ value }: { value: string }) => void;
 } => {
-  const [history, setHistory] = useState<string[]>([]);
+  // used by library users
   const [kana, setKana] = useState<string>('');
+  // library internal use
+  const [previousCharGroups, setPreviousCharGroups] = useState<string[]>([]);
+  const [kanaMap, setKanaMap] = useState<KanaMap>({});
 
   const setKanaSource = ({ value }: { value: string }): void => {
-    const newHistory = value ? [...history, value] : [];
-    setHistory(newHistory);
-    setKana(historykana(newHistory));
+    if (value === '') {
+      setKana('');
+      setKanaMap({});
+      setPreviousCharGroups([]);
+    } else {
+      const currentCharGroups = splitIntoCharGroups(value);
+      const kanaMapDup = createMap(
+        kanaMap,
+        previousCharGroups,
+        currentCharGroups,
+      );
+      const currentKana = convertCharGroupsToKana(
+        kanaMapDup,
+        currentCharGroups,
+      );
+      setKana(currentKana);
+      setKanaMap(kanaMapDup);
+      setPreviousCharGroups(currentCharGroups);
+    }
   };
 
   return { kana, setKanaSource };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "esnext"],
     "module": "es6",
     "moduleResolution": "node",
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.4.0", "@babel/generator@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
@@ -39,6 +59,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
+  dependencies:
+    "@babel/types" "^7.6.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
@@ -77,6 +107,15 @@
     "@babel/traverse" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
+  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
+  dependencies:
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.2"
+    "@babel/types" "^7.6.0"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -90,6 +129,11 @@
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
   integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
+
+"@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.2.0"
@@ -129,10 +173,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.3"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,15 +448,6 @@
     regexpp "^2.0.1"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.2.tgz#e50f31264507e6fec7b33840bb6af260c24f4ea8"
-  integrity sha512-t+JGdTT6dRbmvKDlhlVkEueoZa0fhJNfG6z2cpnRPLwm3VwYr2BjR//acJGC1Yza0I9ZNcDfRY7ubQEvvfG6Jg==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.3.2"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.3.3":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.3.tgz#0685613063ff397cfa9209be2e6e81c0382a9b11"
@@ -492,16 +483,6 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
-
-"@typescript-eslint/typescript-estree@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.2.tgz#107414aa04e689fe6f7251eb63fb500217f2b7f4"
-  integrity sha512-eZNEAai16nwyhIVIEaWQlaUgAU3S9CkQ58qvK0+3IuSdLJD3W1PNuehQFMIhW/mTP1oFR9GNoTcLg7gtXz6lzA==
-  dependencies:
-    glob "^7.1.4"
-    is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
-    semver "^6.3.0"
 
 "@typescript-eslint/typescript-estree@2.3.3":
   version "2.3.3"
@@ -963,13 +944,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-compact-diff@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/compact-diff/-/compact-diff-0.0.3.tgz#90d47263de800d1b747a8a4364a022a02a4b8974"
-  integrity sha1-kNRyY96ADRt0eopDZKAioCpLiXQ=
-  dependencies:
-    diff "^1.3.0"
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -1087,7 +1061,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-define-properties@^1.1.1, define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1141,11 +1115,6 @@ diff-sequences@^24.9.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
-diff@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
-  integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
-
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -1194,7 +1163,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.2.1, es-abstract@^1.5.1, es-abstract@^1.7.0:
+es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
   integrity sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
@@ -1459,7 +1428,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -1641,7 +1610,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
@@ -1804,15 +1773,6 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-historykana@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/historykana/-/historykana-1.0.4.tgz#c0158780bef78d40980b839fa4faa63231d93761"
-  integrity sha1-wBWHgL73jUCYC4OfpPqmMjHZN2E=
-  dependencies:
-    compact-diff "0.0.3"
-    extend "^3.0.0"
-    regexp.escape "^1.0.2"
 
 hosted-git-info@^2.1.4:
   version "2.8.4"
@@ -3472,15 +3432,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
-
-regexp.escape@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/regexp.escape/-/regexp.escape-1.0.2.tgz#bcbb6ffe9490ad81b9ef6e9672a18f2a01ba41a0"
-  integrity sha1-vLtv/pSQrYG5726WcqGPKgG6QaA=
-  dependencies:
-    define-properties "^1.1.1"
-    es-abstract "^1.2.1"
-    function-bind "^1.0.2"
 
 regexpp@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
With this pull request, `react-use-kana` no longer depends on `historykana`.
To graduate from it, I need to implement own kana extraction logic.