### PR TITLE
Just pass value via setKanaSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ npm install react-use-kana
 yarn add react-use-kana
 ```
 
+### API
+
+#### `useKana`
+
+This is the only one hook that `react-use-kana` provides.
+
+- `kana: string`
+  - A hiragana string that derived from inputs. You set this value to a text input for a kana field.
+- `setKanaSource: (value: string) => void`
+  - A function to let `useKana` hook know a new input value so that it can derive `kana`. In general, you call this function as `onClick` callback of a text input for a name field which probably has kanjis or non-hiragana characters.
+
 ### Example
 
 Let's see the following simple example.
@@ -35,14 +46,7 @@ const App = () => {
         <div>
           <span>Name</span>
         </div>
-        <input
-          type="text"
-          onChange={e =>
-            setKanaSource({
-              value: e.target.value,
-            })
-          }
-        />
+        <input type="text" onChange={e => setKanaSource(e.target.value)} />
       </div>
       <div>
         <div>

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -8,9 +8,7 @@ describe('when several kanas are converted to kanjis at once', () => {
     expect(result.current.kana).toEqual('');
     ['や', 'やｍ', 'やま', 'やまｄ', 'やまだ', '山田'].forEach(value => {
       act(() => {
-        result.current.setKanaSource({
-          value,
-        });
+        result.current.setKanaSource(value);
       });
     });
     expect(result.current.kana).toEqual('やまだ');
@@ -24,9 +22,7 @@ describe('when kanas are converted to kanjis one by one', () => {
     expect(result.current.kana).toEqual('');
     ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田'].forEach(value => {
       act(() => {
-        result.current.setKanaSource({
-          value,
-        });
+        result.current.setKanaSource(value);
       });
     });
     expect(result.current.kana).toEqual('やまだ');
@@ -42,9 +38,7 @@ describe('when kanas are converted to kanjis one by one', () => {
     ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田', '山打'].forEach(
       value => {
         act(() => {
-          result.current.setKanaSource({
-            value,
-          });
+          result.current.setKanaSource(value);
         });
       },
     );
@@ -60,9 +54,7 @@ describe('when kanas are converted to katakana', () => {
     ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(
       value => {
         act(() => {
-          result.current.setKanaSource({
-            value,
-          });
+          result.current.setKanaSource(value);
         });
       },
     );
@@ -77,9 +69,7 @@ describe('when conversion happened from head', () => {
     expect(result.current.kana).toEqual('');
     ['ｄ', 'だ', '田', 'い田', 'いい田', '飯田'].forEach(value => {
       act(() => {
-        result.current.setKanaSource({
-          value,
-        });
+        result.current.setKanaSource(value);
       });
     });
     expect(result.current.kana).toEqual('いいだ');
@@ -94,9 +84,7 @@ describe('when a full-width space between characters is given', () => {
     ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(
       value => {
         act(() => {
-          result.current.setKanaSource({
-            value,
-          });
+          result.current.setKanaSource(value);
         });
       },
     );
@@ -112,9 +100,7 @@ describe('when a half-width space between characters is given', () => {
     ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(
       value => {
         act(() => {
-          result.current.setKanaSource({
-            value,
-          });
+          result.current.setKanaSource(value);
         });
       },
     );
@@ -139,9 +125,7 @@ describe('when a half-width space between characters is given', () => {
       '李  愛',
     ].forEach(value => {
       act(() => {
-        result.current.setKanaSource({
-          value,
-        });
+        result.current.setKanaSource(value);
       });
     });
     expect(result.current.kana).toEqual('り  あい');

--- a/src/useKana.tsx
+++ b/src/useKana.tsx
@@ -116,7 +116,7 @@ const convertCharGroupsToKana = (
 
 export const useKana = (): {
   kana: string;
-  setKanaSource: ({ value }: { value: string }) => void;
+  setKanaSource: (value: string) => void;
 } => {
   // used by library users
   const [kana, setKana] = useState<string>('');
@@ -124,7 +124,7 @@ export const useKana = (): {
   const [previousCharGroups, setPreviousCharGroups] = useState<string[]>([]);
   const [kanaMap, setKanaMap] = useState<KanaMap>({});
 
-  const setKanaSource = ({ value }: { value: string }): void => {
+  const setKanaSource = (value: string): void => {
     if (value === '') {
       setKana('');
       setKanaMap({});


### PR DESCRIPTION
## Change

This is a breaking change. Now `setKanaSource` accepts just a string, not an object.

## Why?

I thought that there'd be a case when `setKanaSource` accepts more values other than `value` string, but I changed my mind. I don't have any plan to make it do so for now.