### PR TITLE
Allow multiple conversion from kanji to kanji

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 120
 }
-

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -34,17 +34,7 @@ describe('when kanas are converted to kanjis one by one', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    [
-      'や',
-      'やｍ',
-      'やま',
-      '山',
-      '山ｄ',
-      '山だ',
-      '山駄',
-      '山打',
-      '山田',
-    ].forEach(value => {
+    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山駄', '山打', '山田'].forEach(value => {
       act(() => {
         result.current.setKanaSource(value);
       });
@@ -58,13 +48,11 @@ describe('when kanas are converted to katakana', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(
-      value => {
-        act(() => {
-          result.current.setKanaSource(value);
-        });
-      },
-    );
+    ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
     expect(result.current.kana).toEqual('くりす');
   });
 });
@@ -88,13 +76,11 @@ describe('when a full-width space between characters is given', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(
-      value => {
-        act(() => {
-          result.current.setKanaSource(value);
-        });
-      },
-    );
+    ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
     expect(result.current.kana).toEqual('り　あい');
   });
 });
@@ -104,13 +90,11 @@ describe('when a half-width space between characters is given', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(
-      value => {
-        act(() => {
-          result.current.setKanaSource(value);
-        });
-      },
-    );
+    ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
     expect(result.current.kana).toEqual('り あい');
   });
 });
@@ -120,17 +104,7 @@ describe('when a half-width space between characters is given', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    [
-      'ｒ',
-      'り',
-      '李',
-      '李',
-      '李 ',
-      '李  ',
-      '李  あ',
-      '李  あい',
-      '李  愛',
-    ].forEach(value => {
+    ['ｒ', 'り', '李', '李', '李 ', '李  ', '李  あ', '李  あい', '李  愛'].forEach(value => {
       act(() => {
         result.current.setKanaSource(value);
       });

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -112,3 +112,29 @@ describe('when a half-width space between characters is given', () => {
     expect(result.current.kana).toEqual('り  あい');
   });
 });
+
+describe.skip('when converted to strings with kana and non-kana both', () => {
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['あ', 'あい', 'あいう', '亜い卯'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
+    expect(result.current.kana).toEqual('あいう');
+  });
+
+  test('returns kana based on user input', () => {
+    const { result } = renderHook(() => useKana());
+
+    expect(result.current.kana).toEqual('');
+    ['あ', 'あい', 'あいう', 'あ位う'].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
+    expect(result.current.kana).toEqual('あいう');
+  });
+});

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -30,18 +30,25 @@ describe('when kanas are converted to kanjis one by one', () => {
 });
 
 describe('when kanas are converted to kanjis one by one', () => {
-  // TODO Fix a bug
-  test.skip('returns kana based on user input', () => {
+  test('returns kana based on user input', () => {
     const { result } = renderHook(() => useKana());
 
     expect(result.current.kana).toEqual('');
-    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田', '山打'].forEach(
-      value => {
-        act(() => {
-          result.current.setKanaSource(value);
-        });
-      },
-    );
+    [
+      'や',
+      'やｍ',
+      'やま',
+      '山',
+      '山ｄ',
+      '山だ',
+      '山駄',
+      '山打',
+      '山田',
+    ].forEach(value => {
+      act(() => {
+        result.current.setKanaSource(value);
+      });
+    });
     expect(result.current.kana).toEqual('やまだ');
   });
 });


### PR DESCRIPTION
Closes #29 

With this pull request, a user can convert inputs from kanji to kanji.
e.g. `'やま'` => `'山'` => `'耶麻'` (it results that kana is `'やま'`)