### PR TITLE
Outup cjs file for CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "japanese",
     "kana"
   ],
-  "main": "dist/react-use-kana.js",
-  "module": "dist/react-use-kana.js",
+  "main": "dist/react-use-kana.cjs.js",
+  "module": "dist/react-use-kana.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,10 @@ export default {
   input: './src/index.ts',
   output: [
     {
+      file: pkg.main,
+      format: 'cjs',
+    },
+    {
       file: pkg.module,
       format: 'esm',
     },


### PR DESCRIPTION
## Overview
Modify package.json and rollup.config.js to export in .cjs format.

## Occurrence
SyntaxError: Cannot use import statement outside a module

### Cause
Because the output settings in .cjs are not in rollup.config.

