### PR TITLE
Enable to convert to katakana

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This is the only one hook that `react-use-kana` provides.
 - `setKanaSource: (value: string) => void`
   - A function to let `useKana` hook know a new input value so that it can derive `kana`. In general, you call this function as `onClick` callback of a text input for a name field which probably has kanjis or non-hiragana characters.
 
+This hook accepts an option to define its conversion rule.
+
+- `kataType: 'hiragana' | 'katakana'` (Optional)
+  - `'hiragana'` is default. If you'd like to convert to katakana, declare like `useKana({ kanaType: 'katakana' })`.
+
 ### Example
 
 Let's see the following simple example.

--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -1,188 +1,222 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useKana } from '../useKana';
 
-// What's the No.?
-// Conversion pattern: See details in https://docs.google.com/spreadsheets/d/13kMl3XQ2SG9BQTYaP-lUeVPu5I6u7Xi8Gw3H6ErYqyM/edit?usp=sharing
+describe('basic functionality', () => {
+  // What's the No.?
+  // Conversion pattern: See details in https://docs.google.com/spreadsheets/d/13kMl3XQ2SG9BQTYaP-lUeVPu5I6u7Xi8Gw3H6ErYqyM/edit?usp=sharing
 
-// No. 8
-describe('when several kanas are converted to kanjis at once', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
+  // No. 8
+  describe('when several kanas are converted to kanjis at once', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
 
-    expect(result.current.kana).toEqual('');
-    ['や', 'やｍ', 'やま', 'やまｄ', 'やまだ', '山田'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
+      expect(result.current.kana).toEqual('');
+      ['や', 'やｍ', 'やま', 'やまｄ', 'やまだ', '山田'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
       });
+      expect(result.current.kana).toEqual('やまだ');
     });
-    expect(result.current.kana).toEqual('やまだ');
+  });
+
+  // No. 14
+  describe('when kanas are converted to kanjis one by one', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('やまだ');
+    });
+
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山だｎ', '山だな', '山だ名', '山田名'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('やまだな');
+    });
+  });
+
+  // No. 7
+  describe('when kanas are converted to kanjis via some kanjis', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山駄', '山打', '山田'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('やまだ');
+    });
+  });
+
+  // No. 8
+  describe('when kanas are converted to katakana', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('くりす');
+    });
+  });
+
+  // No. 14
+  describe('when conversion happened from head', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['ｄ', 'だ', '田', 'い田', 'いい田', '飯田'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('いいだ');
+    });
+  });
+
+  // No. 14
+  describe('when a full-width space between characters is given', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('り　あい');
+    });
+  });
+
+  // No. 14
+  describe('when a half-width space between characters is given', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('り あい');
+    });
+  });
+
+  // No. 14
+  describe('when a half-width space between characters is given', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['ｒ', 'り', '李', '李', '李 ', '李  ', '李  あ', '李  あい', '李  愛'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('り  あい');
+    });
+  });
+
+  // No. 13
+  describe('when converted to strings with kana and non-kana both', () => {
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['あ', 'あい', 'あいう', '亜い卯'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('あいう');
+    });
+
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['あ', 'あい', 'あいう', 'あ位う'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('あいう');
+    });
+
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['あ', 'あい', '亜い'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('あい');
+    });
+
+    test('returns kana based on user input', () => {
+      const { result } = renderHook(() => useKana());
+
+      expect(result.current.kana).toEqual('');
+      ['あ', 'あい', 'あ位'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('あい');
+    });
   });
 });
 
-// No. 14
-describe('when kanas are converted to kanjis one by one', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
+describe('katakana mode', () => {
+  describe('set kanaType as katakana', () => {
+    test('returns katakana based on user input', () => {
+      const { result } = renderHook(() => useKana({ kanaType: 'katakana' }));
 
-    expect(result.current.kana).toEqual('');
-    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山田'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
+      expect(result.current.kana).toEqual('');
+      ['ｒ', 'り', '李', '李', '李 ', '李  ', '李  あ', '李  あい', '李  愛'].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
       });
+      expect(result.current.kana).toEqual('リ  アイ');
     });
-    expect(result.current.kana).toEqual('やまだ');
-  });
 
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
+    test('it converts all hiragana to katakana', () => {
+      const { result } = renderHook(() => useKana({ kanaType: 'katakana' }));
 
-    expect(result.current.kana).toEqual('');
-    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山だｎ', '山だな', '山だ名', '山田名'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
+      expect(result.current.kana).toEqual('');
+      [
+        'あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわゐゑをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽぁぃぅぇぉっゃゅょわ゙ゐ゙ゔゑ゙を゙',
+      ].forEach(value => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
       });
+      expect(result.current.kana).toEqual(
+        'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヰヱヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポァィゥェォッャュョヷヸヴヹヺ',
+      );
     });
-    expect(result.current.kana).toEqual('やまだな');
-  });
-});
-
-// No. 7
-describe('when kanas are converted to kanjis via some kanjis', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['や', 'やｍ', 'やま', '山', '山ｄ', '山だ', '山駄', '山打', '山田'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('やまだ');
-  });
-});
-
-// No. 8
-describe('when kanas are converted to katakana', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['ｋ', 'く', 'くｒ', 'くり', 'くりｓ', 'くりす', 'クリス'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('くりす');
-  });
-});
-
-// No. 14
-describe('when conversion happened from head', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['ｄ', 'だ', '田', 'い田', 'いい田', '飯田'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('いいだ');
-  });
-});
-
-// No. 14
-describe('when a full-width space between characters is given', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['ｒ', 'り', '李', '李', '李　', '李　あ', '李　あい', '李　愛'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('り　あい');
-  });
-});
-
-// No. 14
-describe('when a half-width space between characters is given', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['ｒ', 'り', '李', '李', '李 ', '李 あ', '李 あい', '李 愛'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('り あい');
-  });
-});
-
-// No. 14
-describe('when a half-width space between characters is given', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['ｒ', 'り', '李', '李', '李 ', '李  ', '李  あ', '李  あい', '李  愛'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('り  あい');
-  });
-});
-
-// No. 13
-describe('when converted to strings with kana and non-kana both', () => {
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['あ', 'あい', 'あいう', '亜い卯'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('あいう');
-  });
-
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['あ', 'あい', 'あいう', 'あ位う'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('あいう');
-  });
-
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['あ', 'あい', '亜い'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('あい');
-  });
-
-  test('returns kana based on user input', () => {
-    const { result } = renderHook(() => useKana());
-
-    expect(result.current.kana).toEqual('');
-    ['あ', 'あい', 'あ位'].forEach(value => {
-      act(() => {
-        result.current.setKanaSource(value);
-      });
-    });
-    expect(result.current.kana).toEqual('あい');
   });
 });


### PR DESCRIPTION
## Issue

closes https://github.com/ohbarye/react-use-kana/issues/233

## Change

Now this hook accepts an option to define its conversion rule.

- `kataType: 'hiragana' | 'katakana'` (Optional)
  - `'hiragana'` is default. If you'd like to convert to katakana, declare like `useKana({ kanaType: 'katakana' })`.