### PR TITLE
reset previous value when user input is empty

### DIFF
--- a/src/__tests__/useKana.test.ts
+++ b/src/__tests__/useKana.test.ts
@@ -20,6 +20,19 @@ describe('basic functionality', () => {
     });
   });
 
+  describe('remove and invalid value after kana converted', () => {
+    test('return empty', () => {
+      const { result } = renderHook(() => useKana());
+      expect(result.current.kana).toEqual('');
+      ['や', 'やｍ', 'やま', 'やまｄ', 'やまだ', '山田', '', 'a'].forEach((value) => {
+        act(() => {
+          result.current.setKanaSource(value);
+        });
+      });
+      expect(result.current.kana).toEqual('');
+    });
+  });
+
   // No. 14
   describe('when kanas are converted to kanjis one by one', () => {
     test('returns kana based on user input', () => {

--- a/src/useKana.tsx
+++ b/src/useKana.tsx
@@ -172,6 +172,7 @@ export const useKana = ({
       setKana('');
       setKanaMap({});
       setPreviousCharGroups([]);
+      setLastConvertedCharGroups([]);
     } else {
       const currentCharGroups = splitIntoCharGroups(value);
       // Create kana map that contains pairs of non-kana and kana based on the original map


### PR DESCRIPTION
# Problem

以下の操作を行った場合、前回の変換結果が表示されてしまう。

1.かな変換を行う
2.すべての文字をクリア
3.適当なアルファベットを入力する

https://codesandbox.io/s/sleepy-wu-y7qydm?file=/src/App.js

https://user-images.githubusercontent.com/8813191/155691573-13503378-fc78-4a90-8ebb-d0098c483301.mp4


# Solution

ユーザー入力値が空のとき前回の変換結果を保持しているであろうstateをクリアするようにしました。

修正後もテストコードがpassしたため、えいやでPRを投げています 🙏 



https://codesandbox.io/s/sleepy-wu-y7qydm?file=/src/App.js
https://user-images.githubusercontent.com/8813191/155690935-ccb18048-7b58-4485-abc4-dfe70bd650c3.mp4


