### PR TITLE
Bump node to v16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
 jobs:
   bundle_npm_dependencies:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -37,7 +37,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     working_directory: ~/react-use-kana
     steps:
       - checkout
@@ -71,7 +71,7 @@ jobs:
 
   typecheck:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:16
     working_directory: ~/react-use-kana
     steps:
       - checkout


### PR DESCRIPTION
Node v12 will be EOL soon and v16 is the current active LTS.

https://nodejs.org/en/about/releases/

<img width="791" alt="image" src="https://user-images.githubusercontent.com/1811616/156867402-612a4466-ec39-4a48-acf8-6df0abc5a786.png">
